### PR TITLE
Fix/webalize test

### DIFF
--- a/.github/linters/phpcs.xml
+++ b/.github/linters/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<ruleset name="super-linter">
+    <description>The default coding standard for usage with GitHub Super-Linter. It just includes PSR12.</description>
+    <rule ref="PSR12" />
+    <rule ref="PSR1.Methods.CamelCapsMethodName">
+        <!-- methods are named to be similar with original PHP functions -->
+        <exclude-pattern>Class/Tools.php</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Properties.ConstantVisibility.NotFound">
+        <!-- still MUST be compatible with PHP/5.6 -->
+        <exclude-pattern>Class/Tools.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -3,10 +3,10 @@ includes:
 
 parameters:
     ignoreErrors:
-      - 
+      -
         message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
         path: ../../test/*.php
       -
-        message: '#Error: Strict comparison using === between mixed and null will always evaluate to false.#'
+        message: '#Strict comparison using === between mixed and null will always evaluate to false.#'
         path: ../../Class/Tools.php
         count: 1

--- a/.github/linters/phpstan.neon
+++ b/.github/linters/phpstan.neon
@@ -6,3 +6,7 @@ parameters:
       - 
         message: '#Reflection error: PHPUnit_Framework_TestCase not found.#'
         path: ../../test/*.php
+      -
+        message: '#Error: Strict comparison using === between mixed and null will always evaluate to false.#'
+        path: ../../Class/Tools.php
+        count: 1

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -3,7 +3,7 @@ name: PHP Composer
 on: [push, pull_request]
 
 env:
-  LANG: "en_US.UTF-8"
+  LANG: "pt_BR.UTF-8"
 
 jobs:
   build:
@@ -11,6 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: pt_BR.UTF-8
+      run: |
+          sudo locale-gen pt_BR.UTF-8
+          sudo update-locale LANG=pt_BR.UTF-8
+    - name: date
+      run: |
+          date
+
     - uses: actions/checkout@v2
 
     - uses: michaelw90/PHP-Lint@master

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -2,8 +2,8 @@ name: PHP Composer
 
 on: [push, pull_request]
 
-env:
-  LANG: "pt_BR.UTF-8"
+#env:
+#  LANG: "pt_BR.UTF-8"
 
 jobs:
   build:
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: pt_BR.UTF-8
-      run: |
-          sudo locale-gen pt_BR.UTF-8
-          sudo update-locale LANG=pt_BR.UTF-8
-    - name: date
-      run: |
-          date
+    #- name: pt_BR.UTF-8
+    #  run: |
+    #      sudo locale-gen pt_BR.UTF-8
+    #      sudo update-locale LANG=pt_BR.UTF-8
+    #- name: date
+    #  run: |
+    #      date
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -2,23 +2,12 @@ name: PHP Composer
 
 on: [push, pull_request]
 
-#env:
-#  LANG: "pt_BR.UTF-8"
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    #- name: pt_BR.UTF-8
-    #  run: |
-    #      sudo locale-gen pt_BR.UTF-8
-    #      sudo update-locale LANG=pt_BR.UTF-8
-    #- name: date
-    #  run: |
-    #      date
-
     - uses: actions/checkout@v2
 
     - uses: michaelw90/PHP-Lint@master
@@ -35,7 +24,9 @@ jobs:
     - name: PHPUnit (php-actions)
       uses: php-actions/phpunit@v5
       with:
-        configuration: phpunit.xml
+        # PHP included in ubunut-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown
+        # therefore PHPUnit group iconvtranslit is excluded
+        configuration: phpunit-github-actions.xml
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -2,6 +2,9 @@ name: PHP Composer
 
 on: [push, pull_request]
 
+env:
+  LANG: "en_US.UTF-8"
+
 jobs:
   build:
 

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1041,6 +1041,7 @@ class Tools
 //            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
             return;
         }
+        echo "first run LC_CTYPE:" . setlocale(LC_CTYPE, "0");
         $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
 //        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
 //        $characterClassificationConversion[0] = 'C';

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -99,7 +99,7 @@ class Tools
     public static $PASSWORD_CHARS = '-23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
     /** @var bool */
-    private static $LC_CTYPE_OK = false;
+//    private static $LC_CTYPE_OK = false;
 
     /**
      * Add or concatenate $delta to given $variable. If the variable is not set, set it.
@@ -1068,46 +1068,46 @@ class Tools
      *
      * @return void
      */
-    private static function lcTypeOk()
-    {
-        if (self::$LC_CTYPE_OK) {
-//            echo "should be already ok";
-//            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
-            return;
-        }
-        echo "first run LC_ALL:" . setlocale(LC_ALL, "0");
-        echo strtolower('StRiDaVe PiSmEnA');
-        $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
-//        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
-//        $characterClassificationConversion[0] = 'C';
-//        unset($characterClassificationConversion[1]);
-        if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {
-//            echo "needs fix";
-            if (
-                array_key_exists(
-                    1,
-                    $characterClassificationConversion
-                ) && $characterClassificationConversion[1] == '1250'
-            ) {
-                //setlocale(LC_CTYPE, 'Czech_Czechia.1250');
-                setlocale(LC_ALL, 'Czech_Czechia.1250');
-            } else {
-                //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
-                //setlocale(LC_CTYPE, 'en_US.UTF-8');
-                setlocale(LC_ALL, 'en_US.UTF-8');
-            }
-//        } else {
-//            echo "Doesnt need fix";
-        }
-        //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
-//        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
-//        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
-//        mb_internal_encoding('UTF-8'); // voodoo
-        error_reporting(E_ALL); // incl E_NOTICE
-//        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
-        self::$LC_CTYPE_OK = true;
-        return;
-    }
+//    private static function lcTypeOk()
+//    {
+//        if (self::$LC_CTYPE_OK) {
+////            echo "should be already ok";
+////            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
+//            return;
+//        }
+//        echo "first run LC_ALL:" . setlocale(LC_ALL, "0");
+//        echo strtolower('StRiDaVe PiSmEnA');
+//        $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
+////        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
+////        $characterClassificationConversion[0] = 'C';
+////        unset($characterClassificationConversion[1]);
+//        if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {
+////            echo "needs fix";
+//            if (
+//                array_key_exists(
+//                    1,
+//                    $characterClassificationConversion
+//                ) && $characterClassificationConversion[1] == '1250'
+//            ) {
+//                //setlocale(LC_CTYPE, 'Czech_Czechia.1250');
+//                setlocale(LC_ALL, 'Czech_Czechia.1250');
+//            } else {
+//                //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
+//                //setlocale(LC_CTYPE, 'en_US.UTF-8');
+//                setlocale(LC_ALL, 'en_US.UTF-8');
+//            }
+////        } else {
+////            echo "Doesnt need fix";
+//        }
+//        //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
+////        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
+////        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
+////        mb_internal_encoding('UTF-8'); // voodoo
+//        error_reporting(E_ALL); // incl E_NOTICE
+////        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
+//        self::$LC_CTYPE_OK = true;
+//        return;
+//    }
 
     /**
      * Date (and time) locally. Uses Tools::$LOCALE.
@@ -1632,38 +1632,40 @@ class Tools
      */
     public static function webalize($string, $charlist = null, $lower = true)
     {
-        self::lcTypeOk(); // set LC_CTYPE so that iconv and strtolower work
+//        self::lcTypeOk(); // set LC_CTYPE so that iconv and strtolower work
         $string = strtr($string, '`\'"^~', '-----');
-        echo "$string " . __LINE__; // debug
+//        echo "$string " . __LINE__; // debug
         if (ICONV_IMPL === 'glibc') {
-            echo 'ICONV_IMPL === glibc';// debug
+//            echo 'ICONV_IMPL === glibc';// debug
             $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // @ was used intentionally
-            echo "$string " . __LINE__; // debug
+//            echo "$string " . __LINE__; // debug
             $string = strtr(
                 $string,
                 "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2" // phpcs:ignore
                 . "\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe", // phpcs:ignore
                 "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt"
             );
-            echo "$string " . __LINE__; // debug
+//            echo "$string " . __LINE__; // debug
         } else {
-            echo 'iconv ASCII//TRANSLIT ' . __LINE__;// debug
+//            echo 'iconv ASCII//TRANSLIT ' . __LINE__;// debug
             $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // @ was used intentionally
-            echo "$string " . __LINE__; // debug
+//            echo "$string " . __LINE__; // debug
         }
         $string = str_replace(['`', "'", '"', '^', '~'], '', $string);
-        echo "$string " . __LINE__; // debug
+//        echo "$string " . __LINE__; // debug
         // todo fix Strict comparison using === between bool and -1 will always evaluate to false.
         if ($lower === -1) {
             $string = strtoupper($string);
-            echo "$string " . __LINE__; // debug
+//            echo "$string " . __LINE__; // debug
         } elseif ($lower) {
             $string = strtolower($string);
-            echo "$string " . __LINE__; // debug
+//            echo "$string " . __LINE__; // debug
         }
-        $string = trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
-        echo "$string " . __LINE__; // debug
-        return $string;
+        return
+//        $string =
+            trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
+//        echo "$string " . __LINE__; // debug
+//        return $string;
     }
 
     /**

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -17,15 +17,25 @@ class Tools
 
     /** @const constants used in ::arrayListed() */
     const ARRL_HTML = 1;
+
     const ARRL_ESC = 2;
+
     const ARRL_JS = 4;
+
     const ARRL_INT = 8;
+
     const ARRL_FLOAT = 16;
+
     const ARRL_EMPTY = 32;
+
     const ARRL_DB_ID = 64;
+
     const ARRL_KEYS = 128;
+
     const ARRL_PATTERN = 256;
+
     const ARRL_LIKE = self::ARRL_ESC | self::ARRL_INT;
+
     const ARRL_PREGQ = self::ARRL_ESC | self::ARRL_FLOAT;
 
     /** var array locale settings used in ::localeDate(), ::localeTime(), ::relativeTime() */
@@ -97,9 +107,6 @@ class Tools
 
     /** @var string characters used in ::randomPassword() */
     public static $PASSWORD_CHARS = '-23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-
-    /** @var bool */
-//    private static $LC_CTYPE_OK = false;
 
     /**
      * Add or concatenate $delta to given $variable. If the variable is not set, set it.
@@ -921,7 +928,7 @@ class Tools
         if (self::nonempty($options['random-id'])) {
             $options['id'] = self::set($options['id'], 'input') . '-' . rand((int) 1e8, (int) (1e9 - 1));
         }
-        if (!isset($options['rows']) and ! self::nonempty($options['type'])) {
+        if (!isset($options['rows']) && !self::nonempty($options['type'])) {
             $options['type'] = 'text';
         }
         if (self::nonempty($options['table'])) {
@@ -1061,53 +1068,6 @@ class Tools
         $key = self::array_search_i($needle, $haystack, $strict, $encoding);
         return $key !== false && isset($haystack[$key]);
     }
-
-    /**
-     * Check LC_CTYPE settings: when locale category LC_CTYPE is set to C or POSIX,
-     * then iconv and strtolower don't work properly.
-     *
-     * @return void
-     */
-//    private static function lcTypeOk()
-//    {
-//        if (self::$LC_CTYPE_OK) {
-////            echo "should be already ok";
-////            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
-//            return;
-//        }
-//        echo "first run LC_ALL:" . setlocale(LC_ALL, "0");
-//        echo strtolower('StRiDaVe PiSmEnA');
-//        $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
-////        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
-////        $characterClassificationConversion[0] = 'C';
-////        unset($characterClassificationConversion[1]);
-//        if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {
-////            echo "needs fix";
-//            if (
-//                array_key_exists(
-//                    1,
-//                    $characterClassificationConversion
-//                ) && $characterClassificationConversion[1] == '1250'
-//            ) {
-//                //setlocale(LC_CTYPE, 'Czech_Czechia.1250');
-//                setlocale(LC_ALL, 'Czech_Czechia.1250');
-//            } else {
-//                //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
-//                //setlocale(LC_CTYPE, 'en_US.UTF-8');
-//                setlocale(LC_ALL, 'en_US.UTF-8');
-//            }
-////        } else {
-////            echo "Doesnt need fix";
-//        }
-//        //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
-////        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
-////        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
-////        mb_internal_encoding('UTF-8'); // voodoo
-//        error_reporting(E_ALL); // incl E_NOTICE
-////        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
-//        self::$LC_CTYPE_OK = true;
-//        return;
-//    }
 
     /**
      * Date (and time) locally. Uses Tools::$LOCALE.
@@ -1293,8 +1253,7 @@ class Tools
         header("Location: $url2", true, $HTTPCode);
         header('Connection: close');
         die('<script type="text/javascript">window.location=' . json_encode($url2) . ";</script>\n"
-            . '<a href="' . $url2 . '">&rarr;</a>' //yes, without escaping
-        );
+            . '<a href="' . $url2 . '">&rarr;</a>'); //yes, without escaping
     }
 
     /**
@@ -1632,40 +1591,26 @@ class Tools
      */
     public static function webalize($string, $charlist = null, $lower = true)
     {
-//        self::lcTypeOk(); // set LC_CTYPE so that iconv and strtolower work
         $string = strtr($string, '`\'"^~', '-----');
-//        echo "$string " . __LINE__; // debug
         if (ICONV_IMPL === 'glibc') {
-//            echo 'ICONV_IMPL === glibc';// debug
             $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // @ was used intentionally
-//            echo "$string " . __LINE__; // debug
             $string = strtr(
                 $string,
                 "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2" // phpcs:ignore
                 . "\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe", // phpcs:ignore
                 "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt"
             );
-//            echo "$string " . __LINE__; // debug
         } else {
-//            echo 'iconv ASCII//TRANSLIT ' . __LINE__;// debug
             $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // @ was used intentionally
-//            echo "$string " . __LINE__; // debug
         }
         $string = str_replace(['`', "'", '"', '^', '~'], '', $string);
-//        echo "$string " . __LINE__; // debug
         // todo fix Strict comparison using === between bool and -1 will always evaluate to false.
         if ($lower === -1) {
             $string = strtoupper($string);
-//            echo "$string " . __LINE__; // debug
         } elseif ($lower) {
             $string = strtolower($string);
-//            echo "$string " . __LINE__; // debug
         }
-        return
-//        $string =
-            trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
-//        echo "$string " . __LINE__; // debug
-//        return $string;
+        return trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
     }
 
     /**

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1075,7 +1075,7 @@ class Tools
 //            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
             return;
         }
-        echo "first run LC_CTYPE:" . setlocale(LC_CTYPE, "0");
+        echo "first run LC_ALL:" . setlocale(LC_ALL, "0");
         echo strtolower('StRiDaVe PiSmEnA');
         $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
 //        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
@@ -1642,7 +1642,7 @@ class Tools
             );
             echo "$string " . __LINE__; // debug
         } else {
-            echo 'iconv ASCII//TRANSLIT';// debug
+            echo 'iconv ASCII//TRANSLIT ' . __LINE__;// debug
             $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // @ was used intentionally
             echo "$string " . __LINE__; // debug
         }

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -439,11 +439,7 @@ class Tools
             }
         } else {
             foreach ($beginning as $value) {
-                if (mb_strtolower(mb_substr(
-                    $text,
-                    0,
-                    mb_strlen($value, $encoding)
-                ), $encoding) === mb_strtolower($value)) {
+                if (mb_strtolower(mb_substr($text, 0, mb_strlen($value, $encoding)), $encoding) === mb_strtolower($value)) { // phpcs:ignore
                     return true;
                 }
             }
@@ -626,12 +622,7 @@ class Tools
             }
         } else {
             foreach ($ending as $value) {
-                if (mb_strtolower(mb_substr(
-                    $text,
-                    -mb_strlen($value, $encoding),
-                    null,
-                    $encoding
-                )) === mb_strtolower($value)) {
+                if (mb_strtolower(mb_substr($text, -mb_strlen($value, $encoding), null, $encoding)) === mb_strtolower($value)) { // phpcs:ignore
                     return true;
                 }
             }
@@ -819,10 +810,7 @@ class Tools
                 . ($inputKey === $value ? ' checked="checked"' : '')
                 . self::wrap($options['radio-class'], ' class="', '"');
             foreach ($options as $optionKey => $optionValue) {
-                if (!in_array(
-                    $optionKey,
-                    ['separator', 'offset', 'radio-class', 'label-class', 'checked', 'id', 'name', 'value', 'between']
-                ) && $optionValue !== null) {
+                if (!in_array($optionKey, ['separator', 'offset', 'radio-class', 'label-class', 'checked', 'id', 'name', 'value', 'between']) && $optionValue !== null) { // phpcs:ignore
                     $result .= ' ' . $optionKey
                         . ($optionValue === true ? '' : '="' . self::escapeJS($optionValue) . '"');
                 }
@@ -956,18 +944,20 @@ class Tools
         $result .= '<' . (isset($options['rows']) ? 'textarea' : 'input');
         $options = array_merge($options, ['name' => self::h($name), 'value' => $value]);
         foreach ($options as $k => $v) {
-            if (is_string($k) && $v !== null && !self::among(
-                $k,
-                'before',
-                'between',
-                'after',
-                'table',
-                'random-id',
-                'label-after',
-                'label-html',
-                'label-class',
-                'value'
-            )) {
+            if (
+                is_string($k) && $v !== null && !self::among(
+                    $k,
+                    'before',
+                    'between',
+                    'after',
+                    'table',
+                    'random-id',
+                    'label-after',
+                    'label-html',
+                    'label-class',
+                    'value'
+                )
+            ) {
                 $result .= ' ' . $k
                     . ($v === true ? '' : '="' . (mb_substr($k, 0, 2) == 'on' ? self::h($v) : self::h($v)) . '"');
             }
@@ -1093,10 +1083,12 @@ class Tools
 //        unset($characterClassificationConversion[1]);
         if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {
 //            echo "needs fix";
-            if (array_key_exists(
-                1,
-                $characterClassificationConversion
-            ) && $characterClassificationConversion[1] == '1250') {
+            if (
+                array_key_exists(
+                    1,
+                    $characterClassificationConversion
+                ) && $characterClassificationConversion[1] == '1250'
+            ) {
                 setlocale(LC_CTYPE, 'Czech_Czechia.1250');
             } else {
                 //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1100,6 +1100,7 @@ class Tools
 //            echo "Doesnt need fix";
         }
         setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
+        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
         self::$LC_CTYPE_OK = true;
         return;
     }
@@ -1633,7 +1634,7 @@ class Tools
         if (ICONV_IMPL === 'glibc') {
             echo 'ICONV_IMPL === glibc';// debug
             $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // @ was used intentionally
-            echo "$string " . __LINE__; // debug            
+            echo "$string " . __LINE__; // debug
             $string = strtr(
                 $string,
                 "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2" // phpcs:ignore

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1050,7 +1050,8 @@ class Tools
             if (array_key_exists(1, $characterClassificationConversion) && $characterClassificationConversion[1] == '1250') {
                 setlocale(LC_CTYPE, 'Czech_Czechia.1250');
             } else {
-                setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
+                //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
+                setlocale(LC_CTYPE, 'en_US.UTF-8');
             }
 //        } else {
 //            echo "Doesnt need fix";

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1536,7 +1536,7 @@ class Tools
     {
         $string = strtr($string, '`\'"^~', '-----');
         if (ICONV_IMPL === 'glibc') {
-            $string = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // intentionally @
+            $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // intentionally @
             $string = strtr(
                 $string,
                 "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2"
@@ -1544,7 +1544,7 @@ class Tools
                 "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt"
             );
         } else {
-            $string = @iconv('UTF-8', 'ASCII//TRANSLIT', $string); // intentionally @
+            $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // intentionally @
         }
         $string = str_replace(['`', "'", '"', '^', '~'], '', $string);
         // todo fix Strict comparison using === between bool and -1 will always evaluate to false.

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1038,11 +1038,11 @@ class Tools
     {
         if (self::$LC_CTYPE_OK) {
 //            echo "should be already ok";
-//            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, 0));
+//            var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"));
             return;
         }
-        $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, 0));
-//        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, 0), $characterClassificationConversion);
+        $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
+//        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
 //        $characterClassificationConversion[0] = 'C';
 //        unset($characterClassificationConversion[1]);
         if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1089,14 +1089,17 @@ class Tools
                     $characterClassificationConversion
                 ) && $characterClassificationConversion[1] == '1250'
             ) {
-                setlocale(LC_CTYPE, 'Czech_Czechia.1250');
+                //setlocale(LC_CTYPE, 'Czech_Czechia.1250');
+                setlocale(LC_ALL, 'Czech_Czechia.1250');
             } else {
                 //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
-                setlocale(LC_CTYPE, 'en_US.UTF-8');
+                //setlocale(LC_CTYPE, 'en_US.UTF-8');
+                setlocale(LC_ALL, 'en_US.UTF-8');
             }
 //        } else {
 //            echo "Doesnt need fix";
         }
+        setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
         self::$LC_CTYPE_OK = true;
         return;
     }

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1102,6 +1102,8 @@ class Tools
         //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
         setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
         setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
+        mb_internal_encoding('UTF-8'); // voodoo
+        error_reporting(E_ALL); // incl E_NOTICE
         echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
         self::$LC_CTYPE_OK = true;
         return;

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1100,11 +1100,11 @@ class Tools
 //            echo "Doesnt need fix";
         }
         //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
-        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
-        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
-        mb_internal_encoding('UTF-8'); // voodoo
+//        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
+//        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
+//        mb_internal_encoding('UTF-8'); // voodoo
         error_reporting(E_ALL); // incl E_NOTICE
-        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
+//        echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
         self::$LC_CTYPE_OK = true;
         return;
     }

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1086,6 +1086,7 @@ class Tools
             return;
         }
         echo "first run LC_CTYPE:" . setlocale(LC_CTYPE, "0");
+        echo strtolower('StRiDaVe PiSmEnA');
         $characterClassificationConversion = explode('.', setlocale(LC_CTYPE, "0"));
 //        var_dump('LC_CTYPE:', setlocale(LC_CTYPE, "0"), $characterClassificationConversion);
 //        $characterClassificationConversion[0] = 'C';

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1626,25 +1626,36 @@ class Tools
     {
         self::lcTypeOk(); // set LC_CTYPE so that iconv and strtolower work
         $string = strtr($string, '`\'"^~', '-----');
+        echo "$string " . __LINE__; // debug
         if (ICONV_IMPL === 'glibc') {
+            echo 'ICONV_IMPL === glibc';// debug
             $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // @ was used intentionally
+            echo "$string " . __LINE__; // debug            
             $string = strtr(
                 $string,
                 "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2" // phpcs:ignore
                 . "\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe", // phpcs:ignore
                 "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt"
             );
+            echo "$string " . __LINE__; // debug
         } else {
+            echo 'iconv ASCII//TRANSLIT';// debug
             $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // @ was used intentionally
+            echo "$string " . __LINE__; // debug
         }
         $string = str_replace(['`', "'", '"', '^', '~'], '', $string);
+        echo "$string " . __LINE__; // debug
         // todo fix Strict comparison using === between bool and -1 will always evaluate to false.
         if ($lower === -1) {
             $string = strtoupper($string);
+            echo "$string " . __LINE__; // debug
         } elseif ($lower) {
             $string = strtolower($string);
+            echo "$string " . __LINE__; // debug
         }
-        return trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
+        $string = trim(preg_replace('#[^a-z0-9' . preg_quote($charlist, '#') . ']+#i', '-', $string), '-');
+        echo "$string " . __LINE__; // debug
+        return $string;
     }
 
     /**

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -1099,7 +1099,9 @@ class Tools
 //        } else {
 //            echo "Doesnt need fix";
         }
-        setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
+        //setlocale(LC_ALL, 'en_US.UTF-8'); // temp - if it works - remove br_PT from yml
+        setlocale(LC_CTYPE, 'en_US.UTF-8'); // todo refactor
+        setlocale(LC_COLLATE, 'en_US.UTF-8');// todo refactor
         echo "after setting en_US.UTF-8:" . setlocale(LC_ALL, "0");
         self::$LC_CTYPE_OK = true;
         return;

--- a/Class/Tools.php
+++ b/Class/Tools.php
@@ -105,7 +105,8 @@ class Tools
      * Add or concatenate $delta to given $variable. If the variable is not set, set it.
      *
      * @param mixed $variable by reference
-     * @param mixed $delta = 1, what to add. []= used for $variable being an array, otherwise += used for numeric $delta and .= otherwise
+     * @param mixed $delta = 1, what to add. []= used for $variable being an array,
+     *     otherwise += used for numeric $delta and .= otherwise
      * @return mixed variable after addition
      */
     public static function add(&$variable, $delta = 1)
@@ -115,7 +116,8 @@ class Tools
         } elseif (is_numeric($delta)) {
             $variable = (isset($variable) ? $variable : 0) + $delta;
         } else {
-            $variable = (isset($variable) ? $variable : '') . $delta; //$delta == true becomes '1'; false and null become ''
+            //$delta == true becomes '1'; false and null become ''
+            $variable = (isset($variable) ? $variable : '') . $delta;
         }
         return $variable;
     }
@@ -131,7 +133,10 @@ class Tools
     public static function addMessage($type, $message, $show = false)
     {
         $_SESSION['messages'] = self::setarray($_SESSION['messages']) ? $_SESSION['messages'] : [];
-        $_SESSION['messages'] [] = [is_bool($type) ? ($type ? 'success' : 'warning') : ($type == 'error' ? 'danger' : $type), $message];
+        $_SESSION['messages'] [] = [
+            is_bool($type) ? ($type ? 'success' : 'warning') : ($type == 'error' ? 'danger' : $type),
+            $message
+        ];
         if ($show) {
             self::showMessages();
         }
@@ -218,7 +223,8 @@ class Tools
     /**
      * Like implode() but with more options.
      *
-     * @example: Tools::arrayListed(["Levi's", "Procter & Gamble"], 1, ", ", "<b>", "</b>") --> <b>Levi's</b>, <b>Procter &amp; Gamble</b>
+     * @example: Tools::arrayListed(["Levi's", "Procter & Gamble"], 1, ", ", "<b>", "</b>")
+     *     --> <b>Levi's</b>, <b>Procter &amp; Gamble</b>
      *
      * @param mixed[] $array
      * @param int $flags (optional) set of the following bits
@@ -238,7 +244,8 @@ class Tools
      * @return string
      * @example Tools::arrayListed(["<b>Apple</b>", "Levi's", "H&M"]) --> "<b>Apple</b>,Levi's,H&M"
      * @example Tools::arrayListed(['A', 'B', 0, '', false, null, 'C'], Tools::ARRL_EMPTY) --> "A,B,C"
-     * @example Tools::arrayListed(['about', 'links'], Tools::ARRL_PATTERN, ' | ', '<a href="/en/#" title="#">#</a>', '#')
+     * @example Tools::arrayListed(['about', 'links'], Tools::ARRL_PATTERN, ' | ',
+     *     '<a href="/en/#" title="#">#</a>', '#')
      *  --> '<a href="/en/about" title="about">about</a> | <a href="/en/links" title="links">links</a>'
      */
     public static function arrayListed($array, $flags = 0, $glue = ',', $before = '', $after = '')
@@ -356,7 +363,8 @@ class Tools
 
     /**
      * Return the key of given array whose index .. equals ...
-     * @example $array = [0=>['id'=>5,'name'=>'Joe'], 1=>['id'=>17,'name'=>'Irene']]; Tools::arraySearchAssoc(['name'=>'Irene'], $array) --> 1
+     * @example $array = [0=>['id'=>5,'name'=>'Joe'], 1=>['id'=>17,'name'=>'Irene']];
+     *     Tools::arraySearchAssoc(['name'=>'Irene'], $array) --> 1
      * Keys that don't exist are counted as non-matches.
      *
      * @param array $needles
@@ -373,7 +381,10 @@ class Tools
         foreach ($haystack as $key => $value) {
             $matched = 0;
             foreach ($needles as $needleKey => $needleValue) {
-                if (isset($value[$needleKey]) && ($options['strict'] ? $value[$needleKey] === $needleValue : $value[$needleKey] == $needleValue)) {
+                if (
+                    isset($value[$needleKey]) &&
+                    ($options['strict'] ? $value[$needleKey] === $needleValue : $value[$needleKey] == $needleValue)
+                ) {
                     $matched++;
                 } elseif (!$options['partial']) {
                     break;
@@ -428,7 +439,11 @@ class Tools
             }
         } else {
             foreach ($beginning as $value) {
-                if (mb_strtolower(mb_substr($text, 0, mb_strlen($value, $encoding)), $encoding) === mb_strtolower($value)) {
+                if (mb_strtolower(mb_substr(
+                    $text,
+                    0,
+                    mb_strlen($value, $encoding)
+                ), $encoding) === mb_strtolower($value)) {
                     return true;
                 }
             }
@@ -611,7 +626,12 @@ class Tools
             }
         } else {
             foreach ($ending as $value) {
-                if (mb_strtolower(mb_substr($text, -mb_strlen($value, $encoding), null, $encoding)) === mb_strtolower($value)) {
+                if (mb_strtolower(mb_substr(
+                    $text,
+                    -mb_strlen($value, $encoding),
+                    null,
+                    $encoding
+                )) === mb_strtolower($value)) {
                     return true;
                 }
             }
@@ -663,7 +683,11 @@ class Tools
             }
             return substr($result, 1);
         }
-        preg_match_all('~([-\+]?(0x[0-9a-f]+|(0|[1-9][0-9]*)(\.[0-9]+)?(e[-\+]?[0-9]+)?)|\'(\.|[^\'])*\'|"(\.|[^"])*")~i', $input, $matches);
+        preg_match_all(
+            '~([-\+]?(0x[0-9a-f]+|(0|[1-9][0-9]*)(\.[0-9]+)?(e[-\+]?[0-9]+)?)|\'(\.|[^\'])*\'|"(\.|[^"])*")~i',
+            $input,
+            $matches
+        );
         return implode(',', $matches[0]);
     }
 
@@ -789,13 +813,18 @@ class Tools
         self::set($options['between'], ' ');
         foreach ($input as $inputKey => $inputValue) {
             $result .= $options['separator']
-                . ($inputValue !== '' ? '<label' . self::wrap(trim($options['label-class'], ' '), ' class="', '"') . '>' : '')
+                . ($inputValue !== '' ? '<label' . self::wrap(trim($options['label-class'], ' '), ' class="', '"')
+                . '>' : '')
                 . '<input type="radio" name="' . $name . '" value="' . self::h($inputKey) . '"'
                 . ($inputKey === $value ? ' checked="checked"' : '')
                 . self::wrap($options['radio-class'], ' class="', '"');
             foreach ($options as $optionKey => $optionValue) {
-                if (!in_array($optionKey, ['separator', 'offset', 'radio-class', 'label-class', 'checked', 'id', 'name', 'value', 'between']) && $optionValue !== null) {
-                    $result .= ' ' . $optionKey . ($optionValue === true ? '' : '="' . self::escapeJS($optionValue) . '"');
+                if (!in_array(
+                    $optionKey,
+                    ['separator', 'offset', 'radio-class', 'label-class', 'checked', 'id', 'name', 'value', 'between']
+                ) && $optionValue !== null) {
+                    $result .= ' ' . $optionKey
+                        . ($optionValue === true ? '' : '="' . self::escapeJS($optionValue) . '"');
                 }
             }
             $result .= '/>' . ($inputValue !== '' ? $options['between'] . self::h($inputValue) . '</label>' : '');
@@ -927,15 +956,30 @@ class Tools
         $result .= '<' . (isset($options['rows']) ? 'textarea' : 'input');
         $options = array_merge($options, ['name' => self::h($name), 'value' => $value]);
         foreach ($options as $k => $v) {
-            if (is_string($k) && $v !== null && !self::among($k, 'before', 'between', 'after', 'table', 'random-id', 'label-after', 'label-html', 'label-class', 'value')) {
-                $result .= ' ' . $k . ($v === true ? '' : '="' . (mb_substr($k, 0, 2) == 'on' ? self::h($v) : self::h($v)) . '"');
+            if (is_string($k) && $v !== null && !self::among(
+                $k,
+                'before',
+                'between',
+                'after',
+                'table',
+                'random-id',
+                'label-after',
+                'label-html',
+                'label-class',
+                'value'
+            )) {
+                $result .= ' ' . $k
+                    . ($v === true ? '' : '="' . (mb_substr($k, 0, 2) == 'on' ? self::h($v) : self::h($v)) . '"');
             }
         }
-        $result .= isset($options['rows']) ? '>' . self::h($value) . '</textarea>' : ' value="' . self::h($value) . '"/>';
-        $label = self::among($label, '', false, null) ? '' : '<label' . self::wrap(self::h(self::set($options['id'])), ' for="', '"')
+        $result .= isset($options['rows']) ? '>' . self::h($value) . '</textarea>' : ' value="'
+            . self::h($value) . '"/>';
+        $label = self::among($label, '', false, null) ? '' : '<label'
+            . self::wrap(self::h(self::set($options['id'])), ' for="', '"')
             . self::wrap(self::h(self::set($options['label-class'], '')), ' class="', '"') . '>' . $label . '</label>';
         return self::setifempty($options['before']) . (self::nonempty($options['label-after']) ? $result : $label)
-            . self::setifempty($options['between']) . (self::nonempty($options['label-after']) ? $label : $result) . self::setifempty($options['after']);
+            . self::setifempty($options['between']) . (self::nonempty($options['label-after']) ? $label : $result)
+            . self::setifempty($options['after']);
     }
 
     /**
@@ -1048,7 +1092,10 @@ class Tools
 //        unset($characterClassificationConversion[1]);
         if (in_array($characterClassificationConversion[0], ['C', 'POSIX'])) {
 //            echo "needs fix";
-            if (array_key_exists(1, $characterClassificationConversion) && $characterClassificationConversion[1] == '1250') {
+            if (array_key_exists(
+                1,
+                $characterClassificationConversion
+            ) && $characterClassificationConversion[1] == '1250') {
                 setlocale(LC_CTYPE, 'Czech_Czechia.1250');
             } else {
                 //setlocale(LC_CTYPE, 'cs_CZ.UTF-8');
@@ -1075,7 +1122,7 @@ class Tools
             $datetime = strtotime($datetime);
         }
         $language = isset(self::$LOCALE[$language]) ? $language : 'en';
-        $format = date('Y', $datetime) == date('Y') ? self::$LOCALE[$language]['date format'] : self::$LOCALE[$language]['full date format'];
+        $format = date('Y', $datetime) == date('Y') ? self::$LOCALE[$language]['date format'] : self::$LOCALE[$language]['full date format']; // phpcs:ignore
         $date = date($format, +$datetime);
         if ($language != 'en') {
             $date = strtr($date, self::$LOCALE[$language]['months']);
@@ -1160,7 +1207,8 @@ class Tools
      * @param string $form1 form for amount of 1
      * @param bool|string $form234 form for amount of 2, 3, or 4 (if false is given, $form5plus will be used)
      * @param string $form5plus form for amount of 5+
-     * @param bool|string $form0 = false (optional) form for amount of 0 (omit it or submit false to use $form5plus instead)
+     * @param bool|string $form0 = false (optional) form for amount of 0
+     *     (omit it or submit false to use $form5plus instead)
      * @param bool $mod100 = false get modulo of 100 from $amount
      * @return string result form
      */
@@ -1232,7 +1280,8 @@ class Tools
     public static function redir($url = '', $HTTPCode = 303)
     {
         $url = parse_url($url);
-        $url2 = (self::set($url['scheme']) ? $url['scheme'] . '://' : (self::set($_SERVER['HTTPS']) == 'on' ? 'https://' : 'http://'))
+        $url2 = (self::set($url['scheme']) ? $url['scheme']
+            . '://' : (self::set($_SERVER['HTTPS']) == 'on' ? 'https://' : 'http://'))
             . (self::set($url['host']) ? $url['host'] : $_SERVER['HTTP_HOST'])
             . (self::set($url['path']) ? $url['path'] : $_SERVER['SCRIPT_NAME'])
             . self::wrap(self::set($url['query']) ? $url['query'] : $_SERVER['QUERY_STRING'], '?')
@@ -1298,7 +1347,7 @@ class Tools
 
     /**
      * If called with just one parameter, returns given variable if it is set and non-zero, false otherwise.
-     * If called with two parameters, assign the 2nd parameter to the 1st if the 1st variable is not set or not non-zero.
+     * If called with 2 parameters, assign the 2nd parameter to the 1st if the 1st variable is not set or not non-zero.
      * For PHP7+ use the ?? operator.
      *
      * @example unset($a); Tools::set($a); --> false
@@ -1380,7 +1429,8 @@ class Tools
     }
 
     /**
-     * Shorten a string to given $limit of characters (with $ellipsis concatenated at the end), shorter strings are returned the same.
+     * Shorten a string to given $limit of characters (with $ellipsis concatenated at the end),
+     * shorter strings are returned the same.
      *
      * @param string $string
      * @param int $limit
@@ -1405,12 +1455,13 @@ class Tools
      */
     public static function showMessages($echo = true)
     {
-        $_SESSION['messages'] = isset($_SESSION['messages']) && is_array($_SESSION['messages']) ? $_SESSION['messages'] : [];
+        $_SESSION['messages'] = isset($_SESSION['messages']) && is_array($_SESSION['messages']) ? $_SESSION['messages'] : []; // phpcs:ignore
         $result = '';
         foreach ((array) $_SESSION['messages'] as $key => $message) {
             if (isset($message[0], $message[1])) {
                 $result .= '<div class="alert alert-dismissible alert-' . self::h($message[0]) . '" role="alert">'
-                    . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>'
+                    . '<button type="button" class="close" data-dismiss="alert" aria-label="Close">'
+                    . '<span aria-hidden="true">&times;</span></button>'
                     . self::$MESSAGE_ICONS[$message[0]] . ' ' . $message[1] . '</div>' . PHP_EOL;
             }
             unset($_SESSION['messages'][$key]);
@@ -1453,8 +1504,16 @@ class Tools
             }
         }
         $result = $domd->saveXML();
-        //strip "<"."?xml version="1.0"?".">\n<x100000000>" from beginning and "</x100000000>\n" @todo: version-sensitive
-        return substr($result, ($pos = strpos($result, '?' . ">") + 12) + ($result[$pos] == "\n" ? 1 : 0) + 3, substr($result, -1) == "\n" ? -14 : -13);
+        //strip "<"."?xml version="1.0"?".">\n<x100000000>" from beginning and "</x100000000>\n"
+        //@todo: version-sensitive
+        return substr(
+            $result,
+            ($pos = strpos(
+                $result,
+                '?' . ">"
+            ) + 12) + ($result[$pos] == "\n" ? 1 : 0) + 3,
+            substr($result, -1) == "\n" ? -14 : -13
+        );
     }
 
     /**
@@ -1510,7 +1569,8 @@ class Tools
     {
         $encoding = $encoding ?: mb_internal_encoding();
         $length = $length === null ? mb_strlen($string, $encoding) - $offset : $length;
-        return $string = mb_substr($string, 0, $offset, $encoding) . mb_substr($string, $offset + $length, null, $encoding);
+        $string = mb_substr($string, 0, $offset, $encoding) . mb_substr($string, $offset + $length, null, $encoding);
+        return $string;
     }
 
     /**
@@ -1560,7 +1620,8 @@ class Tools
     }
 
     /**
-     * String conversion: diacritics --> ASCII, everything else than a-z, A-Z, 0-9, "_", "-" --> "-", then "--" --> "-" and "-" at the ends get trimmed.
+     * String conversion: diacritics --> ASCII, everything else than a-z, A-Z, 0-9, "_", "-" --> "-",
+     *     then "--" --> "-" and "-" at the ends get trimmed.
      *
      * @param string $string string to webalize
      * @param string $charlist (optional) string of chars to be used
@@ -1573,15 +1634,15 @@ class Tools
         self::lcTypeOk(); // set LC_CTYPE so that iconv and strtolower work
         $string = strtr($string, '`\'"^~', '-----');
         if (ICONV_IMPL === 'glibc') {
-            $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // intentionally @
+            $string = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $string); // @ was used intentionally
             $string = strtr(
                 $string,
-                "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2"
-                . "\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe",
+                "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2" // phpcs:ignore
+                . "\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf8\xf9\xfa\xfb\xfc\xfd\xfe", // phpcs:ignore
                 "ALLSSSSTZZZallssstzzzRAAAALCCCEEEEIIDDNNOOOOxRUUUUYTsraaaalccceeeeiiddnnooooruuuuyt"
             );
         } else {
-            $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // intentionally @
+            $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string); // @ was used intentionally
         }
         $string = str_replace(['`', "'", '"', '^', '~'], '', $string);
         // todo fix Strict comparison using === between bool and -1 will always evaluate to false.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `composer.json` file should then contain current version of the class - some
 ```json
 {
     "require": {
-        "godsdev/tools": "^0.3.5"
+        "godsdev/tools": "^0.3.7"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Testing is implemented using `phpunit` in projects folder `vendor/phpunit/phpuni
 vendor/phpunit/phpunit/phpunit
 ```
 
-*Note: The `redir()` method (which performs HTTP redirection) is not included in unit testing.*
+* Note: The `redir()` method (which performs HTTP redirection) is not included in unit testing.*
+* Note: PHP included in ubuntu-latest (for GitHub Actions) does not support iconv //TRANSLIT flag as iconv implementation is unknown, therefore PHPUnit group iconvtranslit is excluded
 
 ### Troubleshooting
 After running `phpunit` you might get error messages saying that certain PHP extension is not available. (See chapter *PHP Extensions* for more). If your project does not require said extension(s), it will run without error messages of this kind. If it does, it's up to You to provide enabling of this/these extension(s).

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^5.6 || ^7.0",
+        "ext-intl" : "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4|^5"
@@ -24,5 +25,6 @@
             "name": "Karel Seidl",
             "email": "seidl@gods.cz"
         }
-    ]
+    ],
+    "license": "proprietary"
 }

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "library",
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.6 || ^7.0",
-        "ext-intl" : "*"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4|^5"

--- a/phpunit-github-actions.xml
+++ b/phpunit-github-actions.xml
@@ -11,4 +11,9 @@
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
+    <groups>
+        <exclude>
+            <group>iconvtranslit</group>
+        </exclude>
+    </groups>
 </phpunit>

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -231,10 +231,14 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('~^\d+$~', (string) $this->tools->GoogleAuthenticatorCode('abc'));
     }
 
-    public function testAllFromHToP()
+    public function testH()
     {
         // h
         $this->assertSame('a&amp;b&quot;c&apos;d&lt;e&gt;f&#0;g', Tools::h('a&b"c\'d<e>f' . "\0g"));
+    }
+
+    public function testHtmlInput()
+    {
         // htmlInput
         $this->assertSame(
             '<input type="text" name="info" value="a&apos;b&quot;c"/>',
@@ -261,8 +265,16 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
+    }
+
+    public function testHtmlOption()
+    {
         // htmlOption
         $this->assertSame('<option value="1">Android</option>' . PHP_EOL, Tools::htmlOption(1, 'Android'));
+    }
+
+    public function testHtmlRadio()
+    {
         // htmlRadio
         $platforms = ['Android', 'iOS'];
         $this->assertSame(
@@ -286,6 +298,10 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
             '<input type="radio" name="platform" value=""/>',
             Tools::htmlRadio('platform', '', 1)
         );
+    }
+
+    public function testHtmlSelect()
+    {
         // htmlSelect
         $platforms = ['Android', 'iOS'];
         $this->assertSame(
@@ -295,6 +311,10 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
             . '</select>' . PHP_EOL,
             Tools::htmlSelect('platform', $platforms, 1, [])
         );
+    }
+
+    public function testHtmlTextArea()
+    {
         // htmlTextarea
         $this->assertSame(
             '<textarea cols="60" rows="5" name="info">abc</textarea>',
@@ -304,6 +324,10 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
             '<textarea class="my-3" cols="61" rows="6" name="info">a&apos;b&quot;c</textarea>',
             Tools::htmlTextarea('info', 'a\'b"c', 61, 6, ['class' => 'my-3'])
         );
+    }
+
+    public function testHttpResponse()
+    {
         // httpResponse
         $response = "content-type: text/html; charset=utf-8\r\npragma: no cache\r\n\r\n<p>Hello, world!</p>\n";
         $this->assertSame([
@@ -318,6 +342,10 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
             'headers' => ['pragma' => 'no cache'],
             'body' => ['abc', 2, true, false, null, ['d' => 'e']]
             ], Tools::httpResponse($response, ['JSON' => true]));
+    }
+
+    public function testAllFromIToP()
+    {
         // ifempty
         $a = 5;
         $this->assertSame(5, Tools::ifempty($a, 6));
@@ -404,7 +432,7 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testAllFromSToZ()
+    public function testAllFromSToU()
     {
         // set
         // unset($a); // not necessary to unset a variable at the beginning of scope
@@ -487,8 +515,16 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('a=1&color=b%26w', Tools::urlChange(['a' => 1, 'color' => 'b&w']));
         $this->assertSame('a=1', Tools::urlChange(['a' => 1, 'color' => ('black' == 'white' ? 'b&w' : null)]));
         $this->assertSame('array%5B0%5D=2&array%5B1%5D=3', Tools::urlChange(['array' => [2, 3]]));
+    }
+
+    public function testWebalize()
+    {
         // webalize
         $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '));
+    }
+
+    public function testWhitelist()
+    {
         // whitelist
         $os = 'Windows';
         Tools::whitelist($os, ['Windows', 'Unix'], 'unsupported');
@@ -496,11 +532,19 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         $os = 'Solaris';
         Tools::whitelist($os, ['Windows', 'Unix'], 'unsupported');
         $this->assertSame('unsupported', $os);
+    }
+
+    public function testWrap()
+    {
         // wrap
         $this->assertSame('<b>Hello</b>', Tools::wrap('Hello', '<b>', '</b>'));
         $this->assertSame('N/A', Tools::wrap('', '<b>', '</b>', 'N/A'));
         $this->assertSame('N/A', Tools::wrap('0', '<b>', '</b>', 'N/A'));
         $this->assertSame('N/A', Tools::wrap([], '<b>', '</b>', 'N/A'));
+    }
+
+    public function testXorCipherDecipher()
+    {
         // xorCipher
         $this->assertSame('', Tools::xorCipher('abc', ''));
         $key = md5(uniqid((string) mt_rand(), true));

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -237,6 +237,9 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('a&amp;b&quot;c&apos;d&lt;e&gt;f&#0;g', Tools::h('a&b"c\'d<e>f' . "\0g"));
     }
 
+    /**
+     * @group iconvtranslit
+     */
     public function testHtmlInput()
     {
         // htmlInput
@@ -518,6 +521,9 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('array%5B0%5D=2&array%5B1%5D=3', Tools::urlChange(['array' => [2, 3]]));
     }
 
+    /**
+     * @group iconvtranslit
+     */
     public function testWebalize()
     {
         // webalize

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -520,7 +520,8 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
     public function testWebalize()
     {
         // webalize
-        $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '));
+        echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, 0); // debug
+        $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '), 'LC_CTYPE: ' . setlocale(LC_CTYPE, 0));
     }
 
     public function testWhitelist()

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -21,6 +21,7 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        phpinfo();exit;//debug
         $this->tools = new Tools();
     }
 

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -522,7 +522,11 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
     {
         // webalize
         echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"); // debug
-        $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '), 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"));
+        $this->assertSame(
+            'zlutoucky-kun',
+            Tools::webalize('žluťoučký - kůň - '),
+            'LC_CTYPE: ' . setlocale(LC_CTYPE, "0")
+        );
     }
 
     public function testWhitelist()

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -21,7 +21,7 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        phpinfo();exit;//debug
+        error_reporting(E_ALL); // incl E_NOTICE
         $this->tools = new Tools();
     }
 
@@ -528,7 +528,7 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
     public function testWebalize()
     {
         // webalize
-        echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"); // debug
+//        echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"); // debug
         $this->assertSame(
             'zlutoucky-kun',
             Tools::webalize('žluťoučký - kůň - '),

--- a/test/ToolsTest.php
+++ b/test/ToolsTest.php
@@ -412,8 +412,9 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
     public function testRelativeTime()
     {
         // relativeTime
-        $this->assertRegExp('/(1 second ago|2 seconds ago)/', Tools::relativeTime(time() - 1)); //made more benevolent
-        $this->assertSame('1 vteřina zpátky', Tools::relativeTime(time() - 1, 'cs'));
+        // 2 seconds are more benevolent
+        $this->assertRegExp('/(1 second ago|2 seconds ago)/', Tools::relativeTime(time() - 1));
+        $this->assertRegExp('/(1 vteřina zpátky|2 vteřiny zpátky)/', Tools::relativeTime(time() - 1, 'cs'));
         //to work with PHP7.3
         $this->assertRegExp('/(in 1 second|in a moment)/', Tools::relativeTime(date('Y-m-d H:i:s', time() + 1)));
         $this->assertRegExp('/(za 1 vteřina|za okamžik)/', Tools::relativeTime(time() + 1, 'cs'));
@@ -520,8 +521,8 @@ class ToolsTest extends \PHPUnit_Framework_TestCase
     public function testWebalize()
     {
         // webalize
-        echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, 0); // debug
-        $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '), 'LC_CTYPE: ' . setlocale(LC_CTYPE, 0));
+        echo 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"); // debug
+        $this->assertSame('zlutoucky-kun', Tools::webalize('žluťoučký - kůň - '), 'LC_CTYPE: ' . setlocale(LC_CTYPE, "0"));
     }
 
     public function testWhitelist()


### PR DESCRIPTION
* PHP included in ubuntu-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown, therefore PHPUnit group iconvtranslit is excluded (webalize, htmlInput that uses webalize) for testing at GitHub Actions environment
* PHPCS: 120 characters line length enforced, some other warnings muted
* removed @ in front of inconv to unhide potential issues
* PHPUnit tests displays alse E_NOTICE
* composer.json: license=proprietary added
